### PR TITLE
Added support for 3-character train stops like AVA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ API keys can be obtained by registering on the
 [Metlink Developer Portal](https://opendata.metlink.org.nz/).  **Be sure to subscribe to the "Metlink Open Data API".** Currently this is the only API they offer, and is free, but is still unsubscribed by default.
 
 
-`stop_id` for Train and Cable Car stops is a 4 character alphabetic
+`stop_id` for Train and Cable Car stops is a 3 to 4 character alphabetic
 code, and for bus and ferry stops, is a 4 digit numeric code.
 The IDs are on bus stop signs, or can be looked up on the
 [Metlink](https://metlink.org.nz) main web site.

--- a/custom_components/metlink/config_flow.py
+++ b/custom_components/metlink/config_flow.py
@@ -45,7 +45,7 @@ _LOGGER = logging.getLogger(__name__)
 AUTH_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): cv.string})
 STOP_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_STOP_ID): vol.All(cv.string, vol.Length(min=4, max=4)),
+        vol.Required(CONF_STOP_ID): vol.All(cv.string, vol.Length(min=3, max=4)),
         vol.Optional(CONF_ROUTE, default=""): vol.All(cv.string, vol.Length(max=3)),
         vol.Optional(CONF_DEST, default=""): cv.string,
         vol.Optional(CONF_NUM_DEPARTURES, default=1): cv.positive_int,
@@ -196,7 +196,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_STOPS, default=list(all_stops.keys())
                 ): cv.multi_select(all_stops),
                 vol.Optional(CONF_STOP_ID): vol.All(
-                    cv.string, vol.Length(min=4, max=4)
+                    cv.string, vol.Length(min=3, max=4)
                 ),
                 vol.Optional(CONF_ROUTE, default=""): vol.All(
                     cv.string, vol.Length(max=3)

--- a/custom_components/metlink/translations/en.json
+++ b/custom_components/metlink/translations/en.json
@@ -15,7 +15,7 @@
 		"title": "Add Metlink Stop",
 		"description": "Add a bus or train stop. Check the box to add another.",
 		"data": {
-		    "stop_id": "4 digit or letter stop id.",
+		    "stop_id": "3 to 4 digit or letter stop id.",
 		    "route": "(Optional) Route filter.",
 		    "destination": "(Optional} Final destination filter.",
 		    "num_departures": "Number of departures to track. (Default: 1)",
@@ -31,7 +31,7 @@
 		"description": "Add or remove stops.",
 		"data": {
 		    "stops": "Existing stops (unselect to remove)",
-		    "stop_id": "4 digit or letter stop id.",
+		    "stop_id": "3 to 4 digit or letter stop id.",
 		    "route": "(Optional) Route filter.",
 		    "destination": "(Optional) Final destination filter.",
 		    "num_departures": "Number of departures to track. (Default: 1)"


### PR DESCRIPTION
Modified CONF_STOP_ID min length from 4 to 3 chars for stations like AVA