### PR TITLE
Adding support for filtering on multiple routes for the same stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The IDs are on bus stop signs, or can be looked up on the
 [Metlink](https://metlink.org.nz) main web site.
 
 
-If your stop is busy with multiple routes, you can filter by route and/or destination.  Currently exact matches are expected and only a single route or destination can be specified, though the destination does check the name as well as the stop id for a match, but some of the names that come through the API are abbreviated in ways that do not match the main web site so stop id will be more reliable.  The destination filter is only available on the final destination, not any intermediate stops.
+If your stop is busy with multiple routes, you can filter by route and/or destination. Route filters are exact matches against `service_id`, and can be provided as a single value (for example `KPL`) or comma-separated values (for example `KPL,HVL`). Destination still supports a single value, and checks both destination name and stop id for a match, but some names coming through the API are abbreviated in ways that do not match the main web site, so stop id will be more reliable. The destination filter is only available on the final destination, not any intermediate stops.
 
 
 Each stop will create a sensor in Home Assistant, which will return the next departure time as its status.

--- a/custom_components/metlink/config_flow.py
+++ b/custom_components/metlink/config_flow.py
@@ -46,7 +46,7 @@ AUTH_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): cv.string})
 STOP_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_STOP_ID): vol.All(cv.string, vol.Length(min=3, max=4)),
-        vol.Optional(CONF_ROUTE, default=""): vol.All(cv.string, vol.Length(max=3)),
+        vol.Optional(CONF_ROUTE, default=""): cv.string,
         vol.Optional(CONF_DEST, default=""): cv.string,
         vol.Optional(CONF_NUM_DEPARTURES, default=1): cv.positive_int,
         vol.Optional("add_another", default=False): cv.boolean,
@@ -199,7 +199,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     cv.string, vol.Length(min=3, max=4)
                 ),
                 vol.Optional(CONF_ROUTE, default=""): vol.All(
-                    cv.string, vol.Length(max=3)
+                    cv.string
                 ),
                 vol.Optional(CONF_DEST, default=""): cv.string,
                 vol.Optional(CONF_NUM_DEPARTURES, default=1): cv.positive_int,

--- a/custom_components/metlink/sensor.py
+++ b/custom_components/metlink/sensor.py
@@ -143,6 +143,14 @@ def slug(text: str):
     return "_".join(re.split(r'["#$%&+,/:;=?@\[\\\]^`{|}~\'\s]+', text))
 
 
+def parse_route_filters(route_filter: Optional[str]) -> set[str]:
+    """Parse comma-separated route filter input into a set of route IDs."""
+    if route_filter in (None, ""):
+        return set()
+
+    return {route.strip() for route in route_filter.split(",") if route.strip()}
+
+
 def metlink_unique_id(d: Dict):
     uid = "metlink_" + d["stop_id"]
     if "route_filter" in d and d["route_filter"] not in (None, ""):
@@ -166,6 +174,7 @@ class MetlinkSensor(Entity):
         self.metlink = metlink
         self.stop_id = stop[CONF_STOP_ID]
         self.route_filter = stop.get(CONF_ROUTE, None)
+        self.route_filters = parse_route_filters(self.route_filter)
         self.dest_filter = stop.get(CONF_DEST, None)
         self.num_departures = stop.get(CONF_NUM_DEPARTURES, 1)
         if self.num_departures < 1:
@@ -227,8 +236,8 @@ class MetlinkSensor(Entity):
 
             for departure in data[ATTR_DEPARTURES]:
                 dest = departure[ATTR_DESTINATION].get(ATTR_NAME)
-                if self.route_filter not in (None, ""):
-                    if departure[ATTR_SERVICE] != self.route_filter:
+                if self.route_filters:
+                    if departure[ATTR_SERVICE] not in self.route_filters:
                         continue
                 if self.dest_filter not in (None, ""):
                     if (

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -187,6 +187,44 @@ async def test_flow_stops_creates_config_entry(m_metlink_flow, m_metlink_sensor,
 
 
 @patch("custom_components.metlink.sensor.Metlink")
+@patch("custom_components.metlink.config_flow.Metlink")
+async def test_flow_stops_creates_config_entry_with_multi_route(
+    m_metlink_flow, m_metlink_sensor, hass
+):
+    """Test config entry creation accepts comma-separated route filters."""
+    m_instance = AsyncMock()
+    m_instance.get_predictions = AsyncMock()
+    m_instance.get_service_alerts = AsyncMock(return_value={"entity": []})
+    m_metlink_flow.return_value = m_instance
+    m_metlink_sensor.return_value = m_instance
+    config_flow.MetlinkNZConfigFlow.data = {
+        CONF_API_KEY: "dummy",
+        CONF_STOPS: [],
+    }
+    _result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": "stop"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        _result["flow_id"],
+        user_input={CONF_STOP_ID: "1111", CONF_ROUTE: "2,18,24"},
+    )
+
+    expected_data = {
+        CONF_API_KEY: "dummy",
+        CONF_STOPS: [
+            {
+                CONF_STOP_ID: "1111",
+                CONF_ROUTE: "2,18,24",
+                CONF_DEST: "",
+                CONF_NUM_DEPARTURES: 1,
+            }
+        ],
+    }
+    assert result["type"] == "create_entry"
+    assert result["data"] == expected_data
+
+
+@patch("custom_components.metlink.sensor.Metlink")
 async def test_options_flow_init(m_metlink, hass):
     """Test config flow options."""
     m_instance = AsyncMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,7 +25,7 @@ from custom_components.metlink.const import (
     CONF_ROUTE,
     CONF_STOP_ID,
 )
-from custom_components.metlink.sensor import MetlinkSensor, slug
+from custom_components.metlink.sensor import MetlinkSensor, parse_route_filters, slug
 
 TEST_RESPONSE = [
     {
@@ -235,6 +235,30 @@ async def test_async_update_multiple(hass, aioclient_mock):
     assert sensor.name == "Metlink WELL"
     assert sensor.unique_id == "metlink_WELL_rKPL"
     assert sensor.state == dt_util.parse_datetime(expected["departure"])
+
+
+async def test_async_update_multiple_route_filter(hass, aioclient_mock):
+    """Tests that comma-separated route filters are supported."""
+    metlink = MagicMock()
+    metlink.get_predictions = AsyncMock(side_effect=TEST_RESPONSE)
+    metlink.get_service_alerts = AsyncMock(return_value={"entity": []})
+    sensor = MetlinkSensor(
+        metlink,
+        {CONF_STOP_ID: "WELL", CONF_ROUTE: " KPL, HVL ", CONF_NUM_DEPARTURES: 1},
+    )
+    await sensor.async_update()
+
+    assert sensor.available is True
+    assert sensor.attrs["service_id"] == "HVL"
+    assert sensor.attrs["description"] == "HVL UPPE-All stops"
+
+
+def test_parse_route_filters():
+    """Test route filter parser for comma-separated values."""
+    assert parse_route_filters(None) == set()
+    assert parse_route_filters("") == set()
+    assert parse_route_filters("KPL") == {"KPL"}
+    assert parse_route_filters(" KPL, HVL ,, ") == {"KPL", "HVL"}
 
 
 def test_slug():


### PR DESCRIPTION
This PR now allows a single entity to accept a comma separated list of routes to filter the stop predictions.